### PR TITLE
Fixed some biomes not having BiomeDictionary types registered

### DIFF
--- a/src/main/java/epicsquid/traverse/biome/TraverseBiomes.java
+++ b/src/main/java/epicsquid/traverse/biome/TraverseBiomes.java
@@ -143,7 +143,7 @@ public class TraverseBiomes {
   private static void registerBiome(RegistryKey<Biome> key, int weight, BiomeManager.BiomeType type, BiomeDictionary.Type... types) {
     if (weight > 0) {
       BiomeManager.addBiome(type, new BiomeManager.BiomeEntry(key, weight));
-      BiomeDictionary.addTypes(key, types);
     }
+    BiomeDictionary.addTypes(key, types);
   }
 }


### PR DESCRIPTION
Moved `BiomeDictionary#addTypes(RegistryKey, Type...)` outside of the `if (weight > 0)` block in `TraverseBiomes` to fix biomes using `BiomeVariants#addReplacement` not having their dictionary types registered. 

Fixes #49.